### PR TITLE
Update settings to ensure all bindings generate for android sdk

### DIFF
--- a/xamarin/ZendeskXamarinAndroid/ZendeskChatProvidersAndroidBindings/Transforms/Metadata.xml
+++ b/xamarin/ZendeskXamarinAndroid/ZendeskChatProvidersAndroidBindings/Transforms/Metadata.xml
@@ -1,3 +1,4 @@
 ﻿<metadata>
   <remove-node path="/api/package[@name='zendesk.chat']/class[contains(@name, 'Factory')]"/>
+  <remove-node path="/api/package[@name='com.zendesk.service']/class[@name='ZendeskDateTypeAdapter']"/>
 </metadata>

--- a/xamarin/ZendeskXamarinAndroid/ZendeskChatProvidersAndroidBindings/ZendeskChatProvidersAndroidBindings.csproj
+++ b/xamarin/ZendeskXamarinAndroid/ZendeskChatProvidersAndroidBindings/ZendeskChatProvidersAndroidBindings.csproj
@@ -57,9 +57,9 @@
     <LibraryProjectZip Include="..\..\..\android\chat-providers.aar">
       <Link>Jars\chat-providers.aar</Link>
     </LibraryProjectZip>
-    <EmbeddedReferenceJar Include="..\..\..\android\java-common.jar">
+    <EmbeddedJar Include="..\..\..\android\java-common.jar">
       <Link>Jars\java-common.jar</Link>
-    </EmbeddedReferenceJar>
+    </EmbeddedJar>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Square.OkHttp3">


### PR DESCRIPTION
Some bindings required for setting the users visitor info were not being generated due to missing types. This was because a jar was in as a reference jar meaning bindings are not created for it. Changing this fixed the issue